### PR TITLE
adding v16 to supported node versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x] 
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,8 @@
 # Chatpickle Release Notes
 
+## v2.3.0
+Adding v16 to supported node releases
+
 ## v2.2.0
 Readme includes credits page
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,6 @@
 # Chatpickle Release Notes
 
-## v2.3.0
+## v2.2.1
 Adding v16 to supported node releases
 
 ## v2.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "typescript": "^4.2.3"
             },
             "engines": {
-                "node": "^10 || ^12 || ^14 || ^15"
+                "node": "^10 || ^12 || ^14 || ^15 || ^16"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chatpickle",
-    "version": "2.3.0",
+    "version": "2.2.1",
     "description": "Conversation Tests for Chatbots",
     "keywords": [
         "BDD",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "typescript": "^4.2.3"
     },
     "engines": {
-        "node": "^10 || ^12 || ^14 || ^15"
+        "node": "^10 || ^12 || ^14 || ^15 || ^16"
     },
     "jest-junit": {
         "outputDirectory": "reports",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chatpickle",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Conversation Tests for Chatbots",
     "keywords": [
         "BDD",


### PR DESCRIPTION
Adding v16 to the node versions supported in the build.yaml and package.json.

When upgrading a project that had chatpickle as a dependency to use node v16, I noticed an error was thrown when running `npm install`.  The error said
`npm ERR! engine Not compatible with your version of node/npm: chatpickle@2.2.0`

Adding v16 to these two files in Chatpickle should resolve that issue.

I ran the build and test scripts in the chatpickle repo after making these changes to ensure no issues came up in the wake of these additions.